### PR TITLE
Override GetPlayerColor on created ragdolls

### DIFF
--- a/lua/autorun/client/fedh_playercolor.lua
+++ b/lua/autorun/client/fedh_playercolor.lua
@@ -1,0 +1,8 @@
+net.Receive("Fedhoria.SetRagdollColor", function(ln)
+	local ply = net.ReadEntity()
+	local ragdoll = net.ReadEntity()
+
+	ragdoll.GetPlayerColor = function(self)
+		return ply:GetPlayerColor()
+	end
+end)

--- a/lua/fedhoria.lua
+++ b/lua/fedhoria.lua
@@ -4,6 +4,8 @@ local enabled 	= CreateConVar("fedhoria_enabled", 1, bit.bor(FCVAR_ARCHIVE, FCVA
 local players 	= CreateConVar("fedhoria_players", 1, bit.bor(FCVAR_ARCHIVE, FCVAR_REPLICATED))
 local npcs 		= CreateConVar("fedhoria_npcs", 1, bit.bor(FCVAR_ARCHIVE, FCVAR_REPLICATED))
 
+util.AddNetworkString("Fedhoria.SetRagdollColor")
+
 local last_dmgpos = {}
 
 hook.Add("CreateEntityRagdoll", "Fedhoria", function(ent, ragdoll)
@@ -92,6 +94,17 @@ local function CreateRagdoll(self)
 	ragdoll:Spawn()
 
 	ragdoll:SetSkin(self:GetSkin())
+
+	ragdoll.GetPlayerColor = function()
+		return self:GetPlayerColor()
+	end
+
+	timer.Simple(0.1, function()
+		net.Start("Fedhoria.SetRagdollColor")
+			net.WriteEntity(self)
+			net.WriteEntity(ragdoll)
+		net.Broadcast()
+	end)
 
 	for i = 0, self:GetNumBodyGroups() - 1 do
 		ragdoll:SetBodygroup(i, self:GetBodygroup(i))


### PR DESCRIPTION
Was only able to do it after a short delay due to the ragdoll not being created on client at the time of receiving the network message; added a 0.1-second delay. Hopefully there's a better way to do it I'm not thinking of.